### PR TITLE
Fix semantic release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+          cache: 'pip'
       - run: pip install -e .[dev]
       - run: python -m py_compile sidecar/main.py mcp_operator/mcp_operator.py
       - run: pytest --cov=sidecar --cov=mcp_operator --cov-report=term --cov-fail-under=80
@@ -49,7 +50,7 @@ jobs:
           name: build-artifacts
       - name: Semantic Release
         id: semrel
-        uses: python-semantic-release/python-semantic-release@v8
+        uses: python-semantic-release/python-semantic-release@v9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifacts

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ pytest --cov=sidecar --cov=mcp_operator --cov-report=term --cov-fail-under=80
 
 The GitHub Actions workflow builds the sidecar Docker image and packages the
 Helm chart on each push. When changes land on `main`, a release is created using
-**python-semantic-release** which automatically bumps the version, updates the
+**python-semantic-release** (GitHub Action `v9`) which automatically bumps the version, updates the
 changelog and attaches:
 
 - `mcp-sidecar.tar` – the Docker image saved as a tarball
 - `mcp-operator-<version>.tgz` – the packaged Helm chart
 
 Version history lives in [CHANGELOG.md](CHANGELOG.md) and is maintained by
-`python-semantic-release`.
+`python-semantic-release` via the latest GitHub Action.
 
 ## Security
 


### PR DESCRIPTION
## Summary
- cache pip installs in CI
- update python-semantic-release to v9
- document new version in the README

## Testing
- `pytest` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_684ea7e698d8832eb1d2d05237ca1488