### PR TITLE
Fix semantic release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+          cache: 'pip'
       - run: pip install -e .[dev]
       - run: python -m py_compile sidecar/main.py mcp_operator/mcp_operator.py
       - run: pytest --cov=sidecar --cov=mcp_operator --cov-report=term --cov-fail-under=80
@@ -44,12 +48,15 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/download-artifact@v4
         with:
           name: build-artifacts
       - name: Semantic Release
         id: semrel
-        uses: python-semantic-release/python-semantic-release@v8
+        uses: python-semantic-release/python-semantic-release@v9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifacts

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ pytest --cov=sidecar --cov=mcp_operator --cov-report=term --cov-fail-under=80
 
 The GitHub Actions workflow builds the sidecar Docker image and packages the
 Helm chart on each push. When changes land on `main`, a release is created using
-**python-semantic-release** which automatically bumps the version, updates the
+**python-semantic-release** (GitHub Action `v9`) which automatically bumps the version, updates the
 changelog and attaches:
 
 - `mcp-sidecar.tar` – the Docker image saved as a tarball
 - `mcp-operator-<version>.tgz` – the packaged Helm chart
 
 Version history lives in [CHANGELOG.md](CHANGELOG.md) and is maintained by
-`python-semantic-release`.
+`python-semantic-release` via the latest GitHub Action.
 
 ## Security
 

--- a/mcp_operator/__init__.py
+++ b/mcp_operator/__init__.py
@@ -1,1 +1,5 @@
-from .mcp_operator import *
+"""Main package for the Kubernetes MCP operator."""
+
+__version__ = "0.1.0"
+
+from .mcp_operator import *  # noqa: F401,F403

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kube-mcp-operator"
-version = "0.1.0"
+dynamic = ["version"]
 description = "MCP operator and sidecar"
 authors = [
     { name = "Phang", email = "phang98@gmail.com" }
@@ -33,7 +33,10 @@ where = ["."]
 include = ["mcp_operator*", "sidecar*"]
 exclude = ["charts*", "tests*"]
 
+[tool.setuptools.dynamic]
+version = {attr = "mcp_operator.__version__"}
+
 [tool.semantic_release]
-version_variable = "pyproject.toml:project.version"
+version_variable = "mcp_operator/__init__.py:__version__"
 changelog_file = "CHANGELOG.md"
 branch = "main"


### PR DESCRIPTION
## Summary
- cache pip installs in CI
- update python-semantic-release to v9
- document new version in the README
- store version in `mcp_operator.__init__`
- point `semantic_release` to the Python version variable
- fetch entire git history for release

## Testing
- `pip install -e .[dev]` *(fails: could not install build dependencies)*
- `pytest` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_684ea7e698d8832eb1d2d05237ca1488