### PR TITLE
Fix release upload version extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Upload artifacts
         if: steps.semrel.outputs.released == 'true'
         run: |
-          version=$(semantic-release print-version)
+          version="${{ steps.semrel.outputs.version }}"
           gh release upload "v${version}" mcp-sidecar.tar mcp-operator-*.tgz SECURITY.md --repo "$GITHUB_REPOSITORY" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- get release version from the semantic-release action output

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_684ecf39f624832eb6e5c6dabba5db49