### PR TITLE
Add commit linting via semantic release config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: commit-msg-lint
+        name: commit message lint
+        entry: python scripts/validate_commit_msg.py
+        language: system
+        stages: [commit-msg]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,16 @@ Thank you for your interest in contributing to Kube MCP Operator!
   ```bash
   pytest --cov=sidecar --cov=mcp_operator --cov-report=term --cov-fail-under=80
   ```
+- Install the pre-commit hooks which validate commit messages:
+  ```bash
+  pre-commit install --hook-type commit-msg
+  ```
 
 ## Submitting changes
 
 1. Fork the repository and create your branch from `main`.
 2. Make your changes and ensure the tests pass.
-3. Open a pull request describing your changes.
+3. Commit using the Conventional Commits style and one of the tags `feat`, `fix`, `chore`, `docs`, `refactor`, `style`, or `test`.
+4. Open a pull request describing your changes.
 
 Please see [README.md](README.md) for more details about the project.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ metadata:
 ```
 
 When the operator sees this annotation it injects the MCP sidecar and creates a service `<deployment>-mcp` exposing port `8000`.
+Existing annotated deployments are processed on startup so sidecars are injected even if the operator is installed later.
 
 ### Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
 dev = [
     "pytest",
     "pytest-cov",
-    "python-semantic-release"
+    "python-semantic-release",
+    "pre-commit"
 ]
 
 [tool.pytest.ini_options]
@@ -40,3 +41,6 @@ version = {attr = "mcp_operator.__version__"}
 version_variable = "mcp_operator/__init__.py:__version__"
 changelog_file = "CHANGELOG.md"
 branch = "main"
+
+[tool.semantic_release.commit_parser_options]
+allowed_tags = ["feat", "fix", "chore", "docs", "refactor", "style", "test"]

--- a/scripts/validate_commit_msg.py
+++ b/scripts/validate_commit_msg.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import re
+import sys
+
+ALLOWED_TAGS = ["feat", "fix", "chore", "docs", "refactor", "style", "test"]
+
+PATTERN = re.compile(rf'^({'|'.join(ALLOWED_TAGS)}(\([^\n\r\)]+\))?: .+)')
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(0)
+    path = sys.argv[1]
+    with open(path, 'r') as f:
+        first_line = f.readline().strip()
+    if not PATTERN.match(first_line):
+        print(
+            f"Commit message must start with one of {ALLOWED_TAGS} and follow"
+            " the Conventional Commits style.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_operator_extra.py
+++ b/tests/test_operator_extra.py
@@ -73,6 +73,9 @@ class DummyAppsV1Api:
     def list_namespaced_deployment(self, namespace, label_selector=None):
         return types.SimpleNamespace(items=[])
 
+    def list_deployment_for_all_namespaces(self):
+        return types.SimpleNamespace(items=[])
+
     def patch_namespaced_deployment(self, name, namespace, body):
         self.patched = (name, namespace, body)
 


### PR DESCRIPTION
## Summary
- extend dev dependencies with `pre-commit`
- enforce commit messages with a new pre-commit hook
- document commit message rules in CONTRIBUTING
- configure semantic-release allowed tags

## Testing
- `python -m py_compile sidecar/main.py mcp_operator/mcp_operator.py`
- `pip install -e .[dev]` *(fails: Could not connect to pypi.org)*
- `pytest` *(fails: missing pytest-cov due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_684eda36aab8832eab06b584dda99fa4